### PR TITLE
Fix lifetime of `ExclusiveCanvas` canvas references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Switched to `nightly-2025-08-31` compiler
+- Fix lifetime of `ExclusiveCanvas::canvas` and `canvas_mut`
 
 ### Removed
 

--- a/crates/flipperzero/src/gui/mod.rs
+++ b/crates/flipperzero/src/gui/mod.rs
@@ -81,12 +81,26 @@ impl<'a> ExclusiveCanvas<'a> {
     }
 
     /// Get Canvas.
-    pub fn canvas(&self) -> &'a Canvas {
+    ///
+    /// This can't be used with a temporary reference.
+    ///
+    /// ```compile_fail
+    /// # let gui = Gui::open();
+    /// let canvas = gui.direct_draw_acquire().canvas();
+    /// ```
+    pub fn canvas(&self) -> &Canvas {
         unsafe { Canvas::from_raw(self.canvas.as_ptr()) }
     }
 
     /// Get mutable Canvas.
-    pub fn canvas_mut(&mut self) -> &'a mut Canvas {
+    ///
+    /// This can't be used with a temporary reference.
+    ///
+    /// ```compile_fail
+    /// # let gui = Gui::open();
+    /// let canvas = gui.direct_draw_acquire().canvas_mut();
+    /// ```
+    pub fn canvas_mut(&mut self) -> &mut Canvas {
         unsafe { Canvas::from_raw_mut(self.canvas.as_ptr()) }
     }
 }


### PR DESCRIPTION
To get mutable access to a `Canvas` reference you must first call `gui_direct_draw_acquire` then release it with `gui_direct_draw_release` when done.

In our Rust wrapper, this is enforced by returning an `ExclusiveCanvas` handle which represents the claim and can be use for borrowing a `Canvas`.

As such, the following should not compile (temporary value dropped while borrowed):

```rust
let canvas: &mut Canvas = gui.direct_draw_acquire().canvas_mut();
````

However, before this fix it did, due to the borrow happening on `Gui` and not `ExclusiveCanvas`. This would make it impossible to actually write to the Canvas, which was part of the issue in #235.

`ExclusiveCanvas` uses `PhantomData` to hold a "reference" to `Gui`, so by holding a reference to `ExclusiveCanvas` we transitively also hold a reference to `Gui`, thus don't need to explicitly include `Gui`'s lifetime in returned references.